### PR TITLE
amendment to events section

### DIFF
--- a/cleaning-improving.rst
+++ b/cleaning-improving.rst
@@ -11,4 +11,4 @@ We love volunteers, please see the page on the wiki https://wiki.nottinghack.org
 
 For Events
 -------------------------
-For Hack The Space events please see the events page https://wiki.nottinghack.org.uk/wiki/Events
+It is open to members to run, or suggest, events at the Hackspace. To find out more please see the events page https://wiki.nottinghack.org.uk/wiki/Events


### PR DESCRIPTION
Have deleted wording 'Hack The Space events' as doesn't relate specifically to that and is confusing. Added wording to clarify up to members to run/suggest events.